### PR TITLE
Windows 10 support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+* text=auto
+
+*.jpg   binary
+*.png   binary

--- a/bricknil/ble_queue.py
+++ b/bricknil/ble_queue.py
@@ -219,6 +219,9 @@ class BLEventQ(Process):
             hub.ble_id = self.device.address
             self.message_info(f'Device advertised: {device.characteristics}')
             hub.tx = (device, hub.char_uuid)   # Need to store device because the char is not an object in Bleak, unlike Bluefruit library
+            # Hack to fix device name on Windows
+            if self.device.name == "Unknown" and hasattr(device._requester, 'Name'):
+                self.device.name = device._requester.Name
         else:
             self.device.connect()
             hub.ble_id = self.device.id

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-ansible
+ansible; sys_platform != "win32"
 pyobjc; sys_platform == "darwin"
 curio
 fabric

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 ansible
-pyobjc
+pyobjc; sys_platform == "darwin"
 curio
 fabric
 sphinx


### PR DESCRIPTION
This includes some fixes for getting things running on Windows 10. It also requires an updated `bleak` package. See https://github.com/virantha/bleak/pull/1.