### PR TITLE
Remove Adafruit library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,6 @@ htmlcov/
 # pycharm
 .idea/*
 .cache/*
-# adafruit checkout
-Adafruit_Python_BluefruitLE/*
 # C extensions
 *.so
 

--- a/README.rst
+++ b/README.rst
@@ -90,8 +90,7 @@ Features
    * Allows expressive concurrent programming using async/await syntax
    * The current implementation uses the async library Curio_ by David Beazley 
 * Cross-platform
-   * Uses the Adafruit Bluefruit BluetoothLE library for Mac OS X
-   * Uses the Bleak Bluetooth library for Linux and Win10; also tested on Raspberry Pi.
+   * Uses the Bleak Bluetooth Low Energy library
 
 
 .. _Curio: http://curio.readthedocs.io
@@ -503,8 +502,7 @@ Bluetooth event processing.
 .. figure:: images/run_loops.svg
     :align: center
 
-    BrickNil running inside Curio's event loop, which in turn is run by the
-    Adafruit_BluefruitLE library run loop
+    BrickNil running inside Curio's event loop
 
 I'd much have preferred to have the Bluetooth library be implemented via an
 async library like Curio, asyncio, or Trio, but I wasn't able to find any such
@@ -614,11 +612,9 @@ Credits
 This project is also greatly indebted to the following persons, as well as their open-sourced libraries, portions of which have been incorporated into
 BrickNil under the terms of their respective licenses:
 
-* **Tony DiCola** for his Adafruit_Python_BluefruitLE_ library that provides the BluetoothLE communication stack on Mac OS X
-* :gh_user:`Henrik Blidh <hbldh>` for his Bleak_ library that provided a pure python way to communicate with BluetoothLE over DBus on Linux.
+* :gh_user:`Henrik Blidh <hbldh>` for his Bleak_ library that provided a cross-platform, pure python way to communicate with BluetoothLE.
 
 .. _Bleak: https://github.com/hbldh/bleak
-.. _Adafruit_Python_BluefruitLE: https://github.com/adafruit/Adafruit_Python_BluefruitLE
 
 
 Disclaimer

--- a/bricknil/ble_queue.py
+++ b/bricknil/ble_queue.py
@@ -12,24 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Singleton interface to the Adafruit Bluetooth library"""
-import Adafruit_BluefruitLE
 from curio import Queue, sleep, CancelledError
 import sys, functools, uuid
 
 from .sensor import Button # Hack! only to get the button sensor_id for the fake attach message
 from .process import Process
 from .message_dispatch import MessageDispatch
-from .const import USE_BLEAK
 
 # Need a class to represent the bluetooth adapter provided
-# by adafruit that receives messages
 class BLEventQ(Process):
     """All bluetooth comms go through this object
 
        Provides interfaces to connect to a device/hub, send_messages to,
-       and receive_messages from.  Also abstracts away the underlying bluetooth library
-       that depends on the OS (Adafruit_Bluefruit for Mac, and Bleak for Linux/Win10)
+       and receive_messages from.
 
        All requests to send messages to the BLE device must be inserted into
        the :class:`bricknil.BLEventQ.q` Queue object.
@@ -40,18 +35,9 @@ class BLEventQ(Process):
         super().__init__('BLE Event Q')
         self.ble = ble
         self.q = Queue()
-        if USE_BLEAK:
-            self.message('using bleak')
-            self.adapter = None
-            # User needs to make sure adapter is powered up and on
-            #    sudo hciconfig hci0 up
-        else:
-            self.message('Clearing BLE cache data')
-            self.ble.clear_cached_data()
-            self.adapter = self.ble.get_default_adapter()
-            self.message(f'Found adapter {self.adapter.name}')
-            self.message(f'Powering up adapter {self.adapter.name}')
-            self.adapter.power_on()
+        self.adapter = None
+        # User needs to make sure adapter is powered up and on
+        #    sudo hciconfig hci0 up
         self.hubs = {}
 
     async def run(self):
@@ -63,29 +49,22 @@ class BLEventQ(Process):
                 self.message_debug(f'Got msg: {msg_type} = {msg_val}')
                 await self.send_message(hub.tx, msg_val)
         except CancelledError:
-            self.message(f'Terminating and disconnecxting')
-            if USE_BLEAK:
-                await self.ble.in_queue.put( 'quit' )
-            else:
-                self.device.disconnect()
+            self.message(f'Terminating and disconnecting')
+            await self.ble.in_queue.put( 'quit' )
 
     async def send_message(self, characteristic, msg):
         """Prepends a byte with the length of the msg and writes it to
            the characteristic
 
            Arguments:
-              characteristic : An object from bluefruit, or if using Bleak,
-                  a tuple (device, uuid : str)
+              characteristic : A tuple (device, uuid : str)
               msg (bytearray) : Message with header
         """
         # Message needs to have length prepended
         length = len(msg)+1
         values = bytearray([length]+msg)
-        if USE_BLEAK:
-            device, char_uuid = characteristic
-            await self.ble.in_queue.put( ('tx', (device, char_uuid, values)) )
-        else:
-            characteristic.write_value(values)
+        device, char_uuid = characteristic
+        await self.ble.in_queue.put( ('tx', (device, char_uuid, values)) )
 
     async def get_messages(self, hub):
         """Instance a Message object to parse incoming messages and setup
@@ -102,17 +81,9 @@ class BLEventQ(Process):
             self.message_debug(f'Bleak Raw data received: {data}')
             msg = msg_parser.parse(data)
             self.message_debug('{0} Received: {1}'.format(hub.name, msg))
-        def received(data):
-            self.message_debug(f'Adafruit_Bluefruit Raw data received: {data}')
-            msg = msg_parser.parse(data)
-            self.message_debug('{0} Received: {1}'.format(hub.name, msg))
 
-        if USE_BLEAK:
-            device, char_uuid = hub.tx
-            await self.ble.in_queue.put( ('notify', (device, char_uuid, bleak_received) ))
-        else:
-            # Adafruit library does not callback with the sender, only the data
-            hub.tx.start_notify(received)
+        device, char_uuid = hub.tx
+        await self.ble.in_queue.put( ('notify', (device, char_uuid, bleak_received) ))
 
 
     def _check_devices_for(self, devices, name, manufacturer_id, address):
@@ -157,50 +128,30 @@ class BLEventQ(Process):
             self.message_info(f'Looking for first matching hub')
 
         # Start discovery
-        if not USE_BLEAK:
-            self.adapter.start_scan()
+        found = False
+        while not found and timeout > 0:
+            await self.ble.in_queue.put('discover')  # Tell bleak to start discovery
+            devices = await self.ble.out_queue.get() # Wait for discovered devices
+            await self.ble.out_queue.task_done()
+            # Filter out no-matching uuid
+            devices = [d for d in devices if str(uart_uuid) in d.metadata['uuids']]
+            # Now, extract the manufacturer_id
+            for device in devices:
+                assert len(device.metadata['manufacturer_data']) == 1
+                data = next(iter(device.metadata['manufacturer_data'].values())) # Get the one and only key
+                device.manufacturer_id = data[1]
 
-        try:
-            found = False
-            while not found and timeout > 0:
-                if USE_BLEAK:
-                    await self.ble.in_queue.put('discover')  # Tell bleak to start discovery
-                    devices = await self.ble.out_queue.get() # Wait for discovered devices
-                    await self.ble.out_queue.task_done()
-                    # Filter out no-matching uuid
-                    devices = [d for d in devices if str(uart_uuid) in d.uuids]
-                    # NOw, extract the manufacturer_id
-                    for device in devices:
-                        assert len(device.manufacturer_data) == 1
-                        data = next(iter(device.manufacturer_data.values())) # Get the one and only key
-                        device.manufacturer_id = data[1]
-                else:
-                    devices = self.ble.find_devices(service_uuids=[uart_uuid])
-                    for device in devices:
-                        self.message_info(f'advertised: {device.advertised}')
-                        if len(device.advertised) > 4:
-                            device.manufacturer_id = device.advertised[4]
-                        else:
-                            device.manufacturer_id = None
-                        # Remap device.id to device.address to be consistent with bleak
-                        device.address = device.id
-
-                device = self._check_devices_for(devices, ble_name, ble_manufacturer_id,  ble_id)
-                if device:
-                    self.device = device
-                    found = True
-                else:
-                    self.message(f'Rescanning for {uart_uuid} ({timeout} tries left)')
-                    timeout -= 1
-                    self.device = None
-                    await sleep(1)
-            if self.device is None:
-                raise RuntimeError('Failed to find UART device!')
-        except:
-            raise
-        finally:
-            if not USE_BLEAK:
-                self.adapter.stop_scan()
+            device = self._check_devices_for(devices, ble_name, ble_manufacturer_id,  ble_id)
+            if device:
+                self.device = device
+                found = True
+            else:
+                self.message(f'Rescanning for {uart_uuid} ({timeout} tries left)')
+                timeout -= 1
+                self.device = None
+                await sleep(1)
+        if self.device is None:
+            raise RuntimeError('Failed to find UART device!')
 
 
     async def connect(self, hub):
@@ -229,25 +180,15 @@ class BLEventQ(Process):
 
         self.message(f"found device {self.device.name}")
 
-        if USE_BLEAK:
-            await self.ble.in_queue.put( ('connect', self.device.address) )
-            device = await self.ble.out_queue.get()
-            await self.ble.out_queue.task_done()
-            hub.ble_id = self.device.address
-            self.message_info(f'Device advertised: {device.characteristics}')
-            hub.tx = (device, hub.char_uuid)   # Need to store device because the char is not an object in Bleak, unlike Bluefruit library
-            # Hack to fix device name on Windows
-            if self.device.name == "Unknown" and hasattr(device._requester, 'Name'):
-                self.device.name = device._requester.Name
-        else:
-            self.device.connect()
-            hub.ble_id = self.device.id
-            # discover services
-            self.device.discover([hub.uart_uuid], [hub.char_uuid])
-            uart = self.device.find_service(hub.uart_uuid)
-            hub.tx = uart.find_characteristic(hub.char_uuid) # same for rx
-            self.message_info(f'Device advertised {self.device.advertised}')
-
+        await self.ble.in_queue.put( ('connect', self.device.address) )
+        device = await self.ble.out_queue.get()
+        await self.ble.out_queue.task_done()
+        hub.ble_id = self.device.address
+        self.message_info(f'Device advertised: {device.services.characteristics}')
+        hub.tx = (device, hub.char_uuid)
+        # Hack to fix device name on Windows
+        if self.device.name == "Unknown" and hasattr(device._requester, 'Name'):
+            self.device.name = device._requester.Name
 
         self.message_info(f"Connected to device {self.device.name}:{hub.ble_id}")
         self.hubs[hub.ble_id] = hub

--- a/bricknil/bleak_interface.py
+++ b/bricknil/bleak_interface.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Interface to the BLEAK library in Linux for BLE calls
+"""Interface to the BLEAK library for BLE calls
 
 """
 import curio, asyncio, threading, logging

--- a/bricknil/const.py
+++ b/bricknil/const.py
@@ -17,11 +17,6 @@
 from enum import Enum
 import platform
 
-if platform.system() == "Darwin":
-    USE_BLEAK = False
-else:
-    USE_BLEAK = True
-
 class Color(Enum):
     """11 colors"""
     black = 0 

--- a/bricknil/hub.py
+++ b/bricknil/hub.py
@@ -19,7 +19,6 @@ import uuid
 from curio import sleep, UniversalQueue, CancelledError
 from .process import Process
 from .sensor.peripheral import Peripheral  # for type check
-from .const import USE_BLEAK
 from .sockets import WebMessage
 
 class UnknownPeripheralMessage(Exception): pass

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 ansible; sys_platform != "win32"
 pyobjc; sys_platform == "darwin"
 curio
+bleak
 fabric
 sphinx
 sphinx-readable-theme

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pyyaml
 curio
-bluebrick-Adafruit_BluefruitLE >= 0.9.12
+bleak

--- a/setup.py
+++ b/setup.py
@@ -79,8 +79,7 @@ setup (
     zip_safe = True,
     include_package_data = True,
     packages = packages,
-    install_requires = required + ['pyobjc ; sys.platform == "darwin"',
-                                   'bricknil-bleak ; sys.platform != "darwin"'],
+    install_requires = required,
     dependency_links = dependency_links,
     entry_points = {
             'console_scripts': [

--- a/test/test_hub.py
+++ b/test/test_hub.py
@@ -106,14 +106,32 @@ class TestSensors:
         hub = TestHub('test_hub')
 
         # Start the hub
-        #kernel.run(self._emit_control(TestHub))
-        with patch('Adafruit_BluefruitLE.get_provider') as ble,\
-             patch('bricknil.ble_queue.USE_BLEAK', False) as use_bleak:
-            ble.return_value = MockBLE(hub)
-            sensor_obj = getattr(hub, sensor_name)
-            sensor_obj.send_message = Mock(side_effect=coroutine(lambda x,y: "the awaitable should return this"))
-            kernel.run(self._emit_control, data, hub, stop_evt, ble(), sensor_obj)
-            #start(system)
+        sys.modules['bleak'] = MockBleak(hub)
+        sensor_obj = getattr(hub, sensor_name)
+        sensor_obj.send_message = Mock(side_effect=coroutine(lambda x,y: "the awaitable should return this"))
+        from bricknil.bleak_interface import Bleak
+        ble = Bleak()
+        # Run curio in a thread
+        async def dummy(): pass
+
+        async def start_curio():
+            system = await spawn(bricknil.bricknil._run_all(ble, dummy))
+            while len(ble.devices) < 1 or not ble.devices[0].notify:
+                await sleep(0.01)
+            await stop_evt.set()
+            print("sending quit")
+            await ble.in_queue.put( ('quit', ''))
+            #await system.join()
+            print('system joined')
+
+        def start_thread():
+            kernel.run(start_curio)
+
+        t = threading.Thread(target=start_thread)
+        t.start()
+        print('started thread for curio')
+        ble.run()
+        t.join()
 
     async def _wait_send_message(self, mock_call, msg):
         print("in mock")
@@ -164,53 +182,6 @@ class TestSensors:
         
         await hub_stop_evt.set()
         await system.join()
-
-    @given(data = st.data())
-    def test_run_hub_with_bleak(self, data):
-
-        Hub.hubs = []
-        sensor_name = 'sensor'
-        sensor = data.draw(st.sampled_from(self.sensor_list))
-        capabilities = self._draw_capabilities(data, sensor)
-
-        hub_type = data.draw(st.sampled_from(self.hub_list))
-        TestHub, stop_evt = self._get_hub_class(hub_type, sensor, sensor_name, capabilities)
-        hub = TestHub('test_hub')
-
-        async def dummy():
-            pass
-        # Start the hub
-        #MockBleak = MagicMock()
-        sys.modules['bleak'] = MockBleak(hub)
-        with patch('bricknil.bricknil.USE_BLEAK', True), \
-             patch('bricknil.ble_queue.USE_BLEAK', True) as use_bleak:
-            sensor_obj = getattr(hub, sensor_name)
-            sensor_obj.send_message = Mock(side_effect=coroutine(lambda x,y: "the awaitable should return this"))
-            from bricknil.bleak_interface import Bleak
-            ble = Bleak()
-            # Run curio in a thread
-            async def dummy(): pass
-
-            async def start_curio():
-                system = await spawn(bricknil.bricknil._run_all(ble, dummy))
-                while len(ble.devices) < 1 or not ble.devices[0].notify:
-                    await sleep(0.01)
-                await stop_evt.set()
-                print("sending quit")
-                await ble.in_queue.put( ('quit', ''))
-                #await system.join()
-                print('system joined')
-
-            def start_thread():
-                kernel.run(start_curio)
-
-            t = threading.Thread(target=start_thread)
-            t.start()
-            print('started thread for curio')
-            ble.run()
-            t.join()
-
-
 
 
 class MockBleak(MagicMock):

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,5 @@ deps=
     coverage
     curio
     pyyaml
-    bluebrick-Adafruit_BluefruitLE
-    bricknil-bleak
+    bleak
 commands=pytest


### PR DESCRIPTION
bleak now has macOS support, so we don't need the separate Adafriut library for macOS.